### PR TITLE
Feat/install and style button

### DIFF
--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -5,21 +5,21 @@ import * as React from "react";
 import { cn } from "~/lib/utils";
 
 const buttonVariants = cva(
-	"inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 dark:ring-offset-stone-950 dark:focus-visible:ring-stone-300",
+	"inline-flex items-center justify-center whitespace-nowrap rounded-3xl text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 dark:ring-offset-stone-950 dark:focus-visible:ring-stone-300",
 	{
 		variants: {
 			variant: {
 				default:
-					"bg-stone-900 text-stone-50 hover:bg-stone-900/90 dark:bg-stone-50 dark:text-stone-900 dark:hover:bg-stone-50/90",
+					"bg-vd-text-blue text-vd-beige-100 hover:bg-vd-text-blue/90 dark:bg-vd-beige-100 dark:text-vd-text-blue dark:hover:bg-vd-beige-100/90",
 				destructive:
-					"bg-red-500 text-stone-50 hover:bg-red-500/90 dark:bg-red-900 dark:text-stone-50 dark:hover:bg-red-900/90",
+					"bg-red-500 text-vd-beige-100 hover:bg-red-500/90 dark:bg-red-900 dark:text-vd-beige-100 dark:hover:bg-red-900/90",
 				outline:
-					"border border-stone-200 bg-white hover:bg-stone-100 hover:text-stone-900 dark:border-stone-800 dark:bg-stone-950 dark:hover:bg-stone-800 dark:hover:text-stone-50",
+					"border border-vd-text-blue bg-transparent hover:bg-vd-beige-300 hover:text-vd-text-blue dark:border-vd-beige-100 dark:bg-transparent dark:hover:bg-vd-beige-100 dark:hover:text-vd-beige-100",
 				secondary:
-					"bg-stone-100 text-stone-900 hover:bg-stone-100/80 dark:bg-stone-800 dark:text-stone-50 dark:hover:bg-stone-800/80",
+					"bg-vd-gray-300 text-vd-text-blue hover:bg-vd-gray-300/80 dark:bg-vd-beige-100 dark:text-vd-beige-100 dark:hover:bg-vd-beige-100/80",
 				ghost:
-					"hover:bg-stone-100 hover:text-stone-900 dark:hover:bg-stone-800 dark:hover:text-stone-50",
-				link: "text-stone-900 underline-offset-4 hover:underline dark:text-stone-50",
+					"hover:bg-vd-beige-300 hover:text-vd-text-blue dark:hover:bg-vd-beige-100 dark:hover:text-vd-beige-100",
+				link: "text-vd-text-blue underline-offset-4 hover:underline dark:text-vd-beige-100",
 			},
 			size: {
 				default: "h-10 px-4 py-2",

--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -10,16 +10,16 @@ const buttonVariants = cva(
 		variants: {
 			variant: {
 				default:
-					"bg-vd-text-blue text-vd-beige-100 hover:bg-vd-text-blue/90 dark:bg-vd-beige-100 dark:text-vd-text-blue dark:hover:bg-vd-beige-100/90",
+					"bg-vd-blue-900 text-vd-beige-100 hover:bg-vd-blue-900/90 dark:bg-vd-beige-100 dark:text-vd-blue-900 dark:hover:bg-vd-beige-100/90",
 				destructive:
 					"bg-red-500 text-vd-beige-100 hover:bg-red-500/90 dark:bg-red-900 dark:text-vd-beige-100 dark:hover:bg-red-900/90",
 				outline:
-					"border border-vd-text-blue bg-transparent hover:bg-vd-beige-300 hover:text-vd-text-blue dark:border-vd-beige-100 dark:bg-transparent dark:hover:bg-vd-beige-100 dark:hover:text-vd-beige-100",
+					"border border-vd-blue-900 bg-transparent hover:bg-vd-beige-300 hover:text-vd-blue-900 dark:border-vd-beige-100 dark:bg-transparent dark:hover:bg-vd-beige-100 dark:hover:text-vd-beige-100",
 				secondary:
-					"bg-vd-gray-300 text-vd-text-blue hover:bg-vd-gray-300/80 dark:bg-vd-beige-100 dark:text-vd-beige-100 dark:hover:bg-vd-beige-100/80",
+					"bg-vd-gray-300 text-vd-blue-900 hover:bg-vd-gray-300/80 dark:bg-vd-beige-100 dark:text-vd-beige-100 dark:hover:bg-vd-beige-100/80",
 				ghost:
-					"hover:bg-vd-beige-300 hover:text-vd-text-blue dark:hover:bg-vd-beige-100 dark:hover:text-vd-beige-100",
-				link: "text-vd-text-blue underline-offset-4 hover:underline dark:text-vd-beige-100",
+					"hover:bg-vd-beige-300 hover:text-vd-blue-900 dark:hover:bg-vd-beige-100 dark:hover:text-vd-beige-100",
+				link: "text-vd-blue-900 underline-offset-4 hover:underline dark:text-vd-beige-100",
 			},
 			size: {
 				default: "h-10 px-4 py-2",

--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -1,0 +1,58 @@
+import { Slot } from "@radix-ui/react-slot";
+import { type VariantProps, cva } from "class-variance-authority";
+import * as React from "react";
+
+import { cn } from "~/lib/utils";
+
+const buttonVariants = cva(
+	"inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 dark:ring-offset-stone-950 dark:focus-visible:ring-stone-300",
+	{
+		variants: {
+			variant: {
+				default:
+					"bg-stone-900 text-stone-50 hover:bg-stone-900/90 dark:bg-stone-50 dark:text-stone-900 dark:hover:bg-stone-50/90",
+				destructive:
+					"bg-red-500 text-stone-50 hover:bg-red-500/90 dark:bg-red-900 dark:text-stone-50 dark:hover:bg-red-900/90",
+				outline:
+					"border border-stone-200 bg-white hover:bg-stone-100 hover:text-stone-900 dark:border-stone-800 dark:bg-stone-950 dark:hover:bg-stone-800 dark:hover:text-stone-50",
+				secondary:
+					"bg-stone-100 text-stone-900 hover:bg-stone-100/80 dark:bg-stone-800 dark:text-stone-50 dark:hover:bg-stone-800/80",
+				ghost:
+					"hover:bg-stone-100 hover:text-stone-900 dark:hover:bg-stone-800 dark:hover:text-stone-50",
+				link: "text-stone-900 underline-offset-4 hover:underline dark:text-stone-50",
+			},
+			size: {
+				default: "h-10 px-4 py-2",
+				sm: "h-9 rounded-md px-3",
+				lg: "h-11 rounded-md px-8",
+				icon: "h-10 w-10",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+			size: "default",
+		},
+	},
+);
+
+export interface ButtonProps
+	extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+		VariantProps<typeof buttonVariants> {
+	asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+	({ className, variant, size, asChild = false, ...props }, ref) => {
+		const Comp = asChild ? Slot : "button";
+		return (
+			<Comp
+				className={cn(buttonVariants({ variant, size, className }))}
+				ref={ref}
+				{...props}
+			/>
+		);
+	},
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@fontsource-variable/plus-jakarta-sans": "^5.0.19",
+    "@radix-ui/react-slot": "^1.0.2",
     "@remix-run/node": "^2.5.0",
     "@remix-run/react": "^2.5.0",
     "@remix-run/serve": "^2.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   '@fontsource-variable/plus-jakarta-sans':
     specifier: ^5.0.19
     version: 5.0.19
+  '@radix-ui/react-slot':
+    specifier: ^1.0.2
+    version: 1.0.2(@types/react@18.2.47)(react@18.2.0)
   '@remix-run/node':
     specifier: ^2.5.0
     version: 2.5.0(typescript@5.3.3)
@@ -1233,6 +1236,35 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@radix-ui/react-compose-refs@1.0.1(@types/react@18.2.47)(react@18.2.0):
+    resolution: {integrity: sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.8
+      '@types/react': 18.2.47
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-slot@1.0.2(@types/react@18.2.47)(react@18.2.0):
+    resolution: {integrity: sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.8
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.47)(react@18.2.0)
+      '@types/react': 18.2.47
+      react: 18.2.0
+    dev: false
+
   /@remix-run/dev@2.5.0(@remix-run/serve@2.5.0)(typescript@5.3.3)(vite@5.0.11):
     resolution: {integrity: sha512-Px+kyoP21b0/N//VPQ7VRaDZE+oVjTWp4QB1mBwdoCPl9gS7E6LA40YYfY51y/Lts+FSMQPJOLd3yVb9zjzL1w==}
     engines: {node: '>=18.0.0'}
@@ -1602,7 +1634,6 @@ packages:
 
   /@types/prop-types@15.7.11:
     resolution: {integrity: sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==}
-    dev: true
 
   /@types/react-dom@18.2.18:
     resolution: {integrity: sha512-TJxDm6OfAX2KJWJdMEVTwWke5Sc/E/RlnPGvGfS0W7+6ocy2xhDVQVh/KvC2Uf7kACs+gDytdusDSdWfWkaNzw==}
@@ -1616,11 +1647,9 @@ packages:
       '@types/prop-types': 15.7.11
       '@types/scheduler': 0.16.8
       csstype: 3.1.3
-    dev: true
 
   /@types/scheduler@0.16.8:
     resolution: {integrity: sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==}
-    dev: true
 
   /@types/unist@2.0.10:
     resolution: {integrity: sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==}
@@ -2158,7 +2187,6 @@ packages:
 
   /csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
-    dev: true
 
   /data-uri-to-buffer@3.0.1:
     resolution: {integrity: sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,10 +2,10 @@
 module.exports = {
   darkMode: ["class"],
   content: [
-    './pages/**/*.{ts,tsx}',
-    './components/**/*.{ts,tsx}',
-    './app/**/*.{ts,tsx}',
-    './src/**/*.{ts,tsx}',
+    "./pages/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./app/**/*.{ts,tsx}",
+    "./src/**/*.{ts,tsx}",
   ],
   prefix: "",
   theme: {
@@ -18,15 +18,14 @@ module.exports = {
     },
     extend: {
       colors: {
-        // main text 'CloudBurst'
-        "vd-text-blue": "#252F56",
         // page background 'DawnPink'
         "vd-beige-200": "#F7EDE8",
         // container backgrounds
         "vd-beige-400": "#E7C9BA",
         "vd-beige-300": "#F1E0D7",
-        "vd-beige-100": "#FBF7F5",        
+        "vd-beige-100": "#FBF7F5",
         // accent 'Gothic'
+        "vd-blue-900": "#252F56", // main text 'CloudBurst'
         "vd-blue-700": "#3A5264",
         "vd-blue-600": "#416279",
         "vd-blue-500": "#4B778F",
@@ -47,7 +46,6 @@ module.exports = {
         "vd-gray-400": "#92939E",
         "vd-gray-300": "#B9BAC0",
         "vd-gray-200": "#DADADD",
-
       },
       keyframes: {
         "accordion-down": {
@@ -66,4 +64,4 @@ module.exports = {
     },
   },
   plugins: [require("tailwindcss-animate")],
-}
+};


### PR DESCRIPTION
installed button from https://ui.shadcn.com/docs/components/button
updated styles for button to match figma. Since we did not have design for all button variants I improvised following the pattern from replacing the other color values. I will follow up with Chiali to review and confirm.

Note: the primary button background is vd-text-blue. using this var as the background could be confusing.

![Screenshot 2024-01-25 at 3 43 20 PM](https://github.com/VoiceDeck/app/assets/22626267/d15e3a8a-e33a-4cf6-9b06-db53a242e9e9)
