### PR TITLE
chore: use CMS access token when available

### DIFF
--- a/app/directus.server.ts
+++ b/app/directus.server.ts
@@ -6,6 +6,7 @@ import {
 	readItem,
 	readItems,
 	rest,
+	staticToken,
 } from "@directus/sdk";
 import {
 	http,
@@ -271,8 +272,11 @@ export const getDirectusClient = (): DirectusClient<any> & RestClient<any> => {
 	if (!process.env.CMS_ENDPOINT) {
 		throw new Error("[server] CMS_ENDPOINT environment variable is not set");
 	}
+
 	try {
-		directusClient = createDirectus(process.env.CMS_ENDPOINT).with(rest());
+		directusClient = createDirectus(process.env.CMS_ENDPOINT)
+			.with(staticToken(process.env.CMS_ACCESS_TOKEN as string))
+			.with(rest());
 	} catch (error) {
 		console.error(
 			`[server] Failed to create Directus client using endpoint ${process.env.CMS_ENDPOINT}: ${error}`,


### PR DESCRIPTION
This PR updates the Directus client configuration to use the CMS access token when it's available through an environment variable. This change is needed for the production environment. If `CMS_ACCESS_TOKEN` isn't set, the client will simply bypass this step. This won't impact the development environment, as an access token isn't necessary there.