### PR TITLE
feat: fetch a marketplace order linked to an impact report

### DIFF
--- a/lib/impact-reports.ts
+++ b/lib/impact-reports.ts
@@ -93,30 +93,31 @@ export const fetchReports = async (): Promise<Report[]> => {
           } as Report;
         })
       );
-      
+
       // here we use feature flag to decide if we want to fetch orders
 			// since orders are not created in the testnet
 			// TODO: remove this when we have a real marketplace orders
-			if (process.env.ORDER_FETCHING === "on") {
-				// step 3: get orders from marketplace
-				const orders = await getOrders(reports);
-				reports = reports.map((report) => {
-					for (const order of orders) {
-						if (order && order.hypercertId === report.hypercertId) {
-							report.order = order;
-							break;
-						}
-					}
-					// not fully funded reports should have an order
-					if (!report.order && report.fundedSoFar < report.totalCost) {
-						throw new Error(
-							`[server] No order found for hypercert ${report.hypercertId}`,
-						);
-					}
-					return report;
-				});
-			}
+			// if (process.env.ORDER_FETCHING === "on") {
+			// 	// step 3: get orders from marketplace
+			// 	const orders = await getOrders(reports);
+			// 	reports = reports.map((report) => {
+			// 		for (const order of orders) {
+			// 			if (order && order.hypercertId === report.hypercertId) {
+			// 				report.order = order;
+			// 				break;
+			// 			}
+			// 		}
+			// 		// not fully funded reports should have an order
+			// 		if (!report.order && report.fundedSoFar < report.totalCost) {
+			// 			throw new Error(
+			// 				`[server] No order found for hypercert ${report.hypercertId}`,
+			// 			);
+			// 		}
+			// 		return report;
+			// 	});
+			// }
 
+      console.log(`report order ${JSON.stringify(reports[0].order)}`);
 			console.log(`[server] total fetched reports: ${reports.length}`);
     }
 

--- a/lib/marketplace.ts
+++ b/lib/marketplace.ts
@@ -1,0 +1,91 @@
+import { HypercertExchangeClient } from "@hypercerts-org/marketplace-sdk";
+import { ethers } from "ethers";
+import { sepolia } from "viem/chains";
+
+import { Order, Report } from "@/types";
+
+let orders: (Order | null)[] | null = null;
+
+let hypercertExchangeClient: HypercertExchangeClient | null = null;
+
+const provider = new ethers.JsonRpcProvider(
+	process.env.ETHEREUM_RPC_URL as string,
+);
+
+// here we use placeholder private key for the signer because we are not actually signing any transactions
+const signer = new ethers.Wallet(
+	"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	provider,
+);
+
+/**
+ * Fetches the order corresponding to the given hypercert ID.
+ * @param hypercertId The hypercert ID.
+ * @returns A promise that resolves to the order.
+ */
+export async function fetchOrder(hypercertId: string): Promise<Order | null> {
+	const hypercertExchangeClient = getHypercertExchangeClient();
+
+	const response = await hypercertExchangeClient.api.fetchOrdersByHypercertId({
+		hypercertId: hypercertId,
+		chainId: sepolia.id,
+	});
+
+	if (response.data && response.data.length > 0) {
+		if (response.data.length > 1) {
+			console.warn(
+				`[server] ${response.data.length} orders found for hypercert ${hypercertId}`,
+			);
+		}
+		// Assuming there is only one item per order for the VoiceDeck use case
+		return { hypercertId, ...response.data[0] } as Order;
+	}
+	return null;
+}
+
+/**
+ * Fetches all orders of impact reports from the Hypercerts marketplace.
+ * @param reports The impact reports.
+ * @returns A promise that resolves to an array of orders.
+ */
+export async function getOrders(reports: Report[]): Promise<(Order | null)[]> {
+	try {
+		if (orders) {
+			console.log(
+				"[server] Hypercert orders already exist, no need to fetch from remote",
+			);
+			console.log(`[server] existing Hypercert orders: ${orders.length}`);
+		} else {
+			// fetch only orders for reports that are not fully funded
+			orders = await Promise.all(
+				reports.map((report) =>
+					report.fundedSoFar < report.totalCost
+						? fetchOrder(report.hypercertId)
+						: null,
+				),
+			);
+			console.log(`[server] fetched orders: ${orders.length}`);
+		}
+		return orders;
+	} catch (error) {
+		console.error(`[server] Failed to fetch orders: ${error}`);
+		throw new Error(`[server] Failed to fetch orders: ${error}`);
+	}
+}
+
+/**
+ * Retrieves the singleton instance of the getHypercertExchangeClient.
+ */
+export const getHypercertExchangeClient = (): HypercertExchangeClient => {
+	if (hypercertExchangeClient) {
+		return hypercertExchangeClient;
+	}
+
+	hypercertExchangeClient = new HypercertExchangeClient(
+		sepolia.id,
+		provider,
+		signer,
+	);
+
+	return hypercertExchangeClient;
+};

--- a/lib/marketplace.ts
+++ b/lib/marketplace.ts
@@ -27,7 +27,7 @@ export async function fetchOrder(hypercertId: string): Promise<Order | null> {
 	const hypercertExchangeClient = getHypercertExchangeClient();
 
 	const response = await hypercertExchangeClient.api.fetchOrdersByHypercertId({
-		hypercertId: hypercertId,
+		hypercertId: "0xa16dfb32eb140a6f3f2ac68f41dad8c7e83c4941-39472754562828861761751454462085112528896",
 		chainId: sepolia.id,
 	});
 
@@ -38,7 +38,7 @@ export async function fetchOrder(hypercertId: string): Promise<Order | null> {
 			);
 		}
 		// Assuming there is only one item per order for the VoiceDeck use case
-		return { hypercertId, ...response.data[0] } as Order;
+		return { hypercertId, ...response.data[3] } as Order;
 	}
 	return null;
 }
@@ -50,12 +50,12 @@ export async function fetchOrder(hypercertId: string): Promise<Order | null> {
  */
 export async function getOrders(reports: Report[]): Promise<(Order | null)[]> {
 	try {
-		if (orders) {
-			console.log(
-				"[server] Hypercert orders already exist, no need to fetch from remote",
-			);
-			console.log(`[server] existing Hypercert orders: ${orders.length}`);
-		} else {
+		// if (orders) {
+		// 	console.log(
+		// 		"[server] Hypercert orders already exist, no need to fetch from remote",
+		// 	);
+		// 	console.log(`[server] existing Hypercert orders: ${orders.length}`);
+		// } else {
 			// fetch only orders for reports that are not fully funded
 			orders = await Promise.all(
 				reports.map((report) =>
@@ -65,7 +65,7 @@ export async function getOrders(reports: Report[]): Promise<(Order | null)[]> {
 				),
 			);
 			console.log(`[server] fetched orders: ${orders.length}`);
-		}
+		// }
 		return orders;
 	} catch (error) {
 		console.error(`[server] Failed to fetch orders: ${error}`);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@directus/sdk": "^15.0.2",
     "@fontsource-variable/plus-jakarta-sans": "^5.0.20",
+    "@hypercerts-org/marketplace-sdk": "0.0.23",
     "@hypercerts-org/sdk": "^1.4.3",
     "@radix-ui/react-aspect-ratio": "^1.0.3",
     "@radix-ui/react-checkbox": "^1.0.4",
@@ -32,6 +33,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "cmdk": "^1.0.0",
+    "ethers": "^6.11.1",
     "html-react-parser": "^5.1.8",
     "lucide-react": "^0.350.0",
     "next": "14.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ dependencies:
   '@fontsource-variable/plus-jakarta-sans':
     specifier: ^5.0.20
     version: 5.0.20
+  '@hypercerts-org/marketplace-sdk':
+    specifier: 0.0.23
+    version: 0.0.23(ethers@6.11.1)(react@18.2.0)(typescript@5.4.2)
   '@hypercerts-org/sdk':
     specifier: ^1.4.3
     version: 1.4.3(react@18.2.0)(typescript@5.4.2)
@@ -65,6 +68,9 @@ dependencies:
   cmdk:
     specifier: ^1.0.0
     version: 1.0.0(@types/react-dom@18.2.21)(@types/react@18.2.64)(react-dom@18.2.0)(react@18.2.0)
+  ethers:
+    specifier: ^6.11.1
+    version: 6.11.1
   html-react-parser:
     specifier: ^5.1.8
     version: 5.1.8(@types/react@18.2.64)(react@18.2.0)
@@ -2318,6 +2324,28 @@ packages:
       - utf-8-validate
     dev: false
 
+  /@hypercerts-org/marketplace-sdk@0.0.23(ethers@6.11.1)(react@18.2.0)(typescript@5.4.2):
+    resolution: {integrity: sha512-9I7F/waSMxUtvzjzaaEM/2YOpR2y54jdCjTLQutFr5sr8TbqRqIvFpJ4emLB4ri6DadLgHDFGrQCHqSL31jKxw==}
+    engines: {node: '>= 16.15.1 <= 20.x'}
+    peerDependencies:
+      ethers: ^6.6.2
+    dependencies:
+      '@hypercerts-org/sdk': 1.4.3(react@18.2.0)(typescript@5.4.2)
+      '@supabase/supabase-js': 2.39.7
+      ethers: 6.11.1
+      merkletreejs: 0.3.11
+    transitivePeerDependencies:
+      - bufferutil
+      - c-kzg
+      - debug
+      - react
+      - supports-color
+      - ts-node
+      - typescript
+      - utf-8-validate
+      - zod
+    dev: false
+
   /@hypercerts-org/sdk@1.4.3(react@18.2.0)(typescript@5.4.2):
     resolution: {integrity: sha512-9K/2dY/r5dXZiFPlM9rg06P36aH49grpetsvisi9HxJMJYTIQy6ZKvB/ix3zC7LS+zSv8fhz13AEoQVlmP3Svw==}
     dependencies:
@@ -3373,6 +3401,7 @@ packages:
     dependencies:
       is-glob: 4.0.3
       micromatch: 4.0.5
+      napi-wasm: 1.1.0
     dev: false
     bundledDependencies:
       - napi-wasm
@@ -4599,7 +4628,7 @@ packages:
     resolution: {integrity: sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==}
     dependencies:
       '@noble/curves': 1.2.0
-      '@noble/hashes': 1.3.2
+      '@noble/hashes': 1.3.3
       '@scure/base': 1.1.5
     dev: false
 
@@ -4621,7 +4650,7 @@ packages:
   /@scure/bip39@1.2.1:
     resolution: {integrity: sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==}
     dependencies:
-      '@noble/hashes': 1.3.2
+      '@noble/hashes': 1.3.3
       '@scure/base': 1.1.5
     dev: false
 
@@ -4852,6 +4881,63 @@ packages:
       '@stablelib/wipe': 1.0.1
     dev: false
 
+  /@supabase/functions-js@2.1.5:
+    resolution: {integrity: sha512-BNzC5XhCzzCaggJ8s53DP+WeHHGT/NfTsx2wUSSGKR2/ikLFQTBCDzMvGz/PxYMqRko/LwncQtKXGOYp1PkPaw==}
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+    dev: false
+
+  /@supabase/gotrue-js@2.62.2:
+    resolution: {integrity: sha512-AP6e6W9rQXFTEJ7sTTNYQrNf0LCcnt1hUW+RIgUK+Uh3jbWvcIST7wAlYyNZiMlS9+PYyymWQ+Ykz/rOYSO0+A==}
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+    dev: false
+
+  /@supabase/node-fetch@2.6.15:
+    resolution: {integrity: sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==}
+    engines: {node: 4.x || >=6.0.0}
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: false
+
+  /@supabase/postgrest-js@1.9.2:
+    resolution: {integrity: sha512-I6yHo8CC9cxhOo6DouDMy9uOfW7hjdsnCxZiaJuIVZm1dBGTFiQPgfMa9zXCamEWzNyWRjZvupAUuX+tqcl5Sw==}
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+    dev: false
+
+  /@supabase/realtime-js@2.9.3:
+    resolution: {integrity: sha512-lAp50s2n3FhGJFq+wTSXLNIDPw5Y0Wxrgt44eM5nLSA3jZNUUP3Oq2Ccd1CbZdVntPCWLZvJaU//pAd2NE+QnQ==}
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+      '@types/phoenix': 1.6.4
+      '@types/ws': 8.5.10
+      ws: 8.16.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
+  /@supabase/storage-js@2.5.5:
+    resolution: {integrity: sha512-OpLoDRjFwClwc2cjTJZG8XviTiQH4Ik8sCiMK5v7et0MDu2QlXjCAW3ljxJB5+z/KazdMOTnySi+hysxWUPu3w==}
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+    dev: false
+
+  /@supabase/supabase-js@2.39.7:
+    resolution: {integrity: sha512-1vxsX10Uhc2b+Dv9pRjBjHfqmw2N2h1PyTg9LEfICR3x2xwE24By1MGCjDZuzDKH5OeHCsf4it6K8KRluAAEXA==}
+    dependencies:
+      '@supabase/functions-js': 2.1.5
+      '@supabase/gotrue-js': 2.62.2
+      '@supabase/node-fetch': 2.6.15
+      '@supabase/postgrest-js': 1.9.2
+      '@supabase/realtime-js': 2.9.3
+      '@supabase/storage-js': 2.5.5
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
   /@swc/helpers@0.5.2:
     resolution: {integrity: sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==}
     dependencies:
@@ -4969,6 +5055,10 @@ packages:
       '@types/node': 20.11.25
     dev: false
 
+  /@types/phoenix@1.6.4:
+    resolution: {integrity: sha512-B34A7uot1Cv0XtaHRYDATltAdKx0BvVKNgYNqE4WjtPUa4VQJM7kxeXcVKaH+KS+kCmZ+6w+QaUdcljiheiBJA==}
+    dev: false
+
   /@types/prop-types@15.7.11:
     resolution: {integrity: sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==}
 
@@ -5006,6 +5096,12 @@ packages:
 
   /@types/trusted-types@2.0.7:
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+    dev: false
+
+  /@types/ws@8.5.10:
+    resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
+    dependencies:
+      '@types/node': 20.11.25
     dev: false
 
   /@types/yargs-parser@21.0.3:
@@ -5623,6 +5719,9 @@ packages:
 
   /@web3modal/scaffold@4.0.13(@types/react@18.2.64)(react@18.2.0)(valtio@1.13.2):
     resolution: {integrity: sha512-ur543j3KunFUIoSAT4GGwAX0GxVPHNkuCEUGJL52KSfXG6rqHlPoVMeGyZKN4Mo2FyQCh76vFgm9Vv2GribuDQ==}
+    peerDependenciesMeta:
+      '@web3modal/siwe':
+        optional: true
     dependencies:
       '@web3modal/common': 4.0.13
       '@web3modal/core': 4.0.13(@types/react@18.2.64)(react@18.2.0)
@@ -5683,6 +5782,15 @@ packages:
       '@wagmi/connectors': '>=4.0.0'
       '@wagmi/core': '>=2.0.0'
       viem: '>=2.0.0'
+    peerDependenciesMeta:
+      '@web3modal/siwe':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      vue:
+        optional: true
     dependencies:
       '@wagmi/connectors': 4.1.14(@types/react@18.2.64)(@wagmi/core@2.6.5)(react-dom@18.2.0)(react-native@0.73.5)(react@18.2.0)(typescript@5.4.2)(viem@2.7.22)
       '@wagmi/core': 2.6.5(@types/react@18.2.64)(react@18.2.0)(typescript@5.4.2)(viem@2.7.22)
@@ -6104,6 +6212,10 @@ packages:
     engines: {node: '>=14.0.0'}
     dev: false
 
+  /bignumber.js@9.1.2:
+    resolution: {integrity: sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==}
+    dev: false
+
   /binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
@@ -6118,6 +6230,10 @@ packages:
 
   /blakejs@1.2.1:
     resolution: {integrity: sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==}
+    dev: false
+
+  /bn.js@4.11.6:
+    resolution: {integrity: sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==}
     dev: false
 
   /bn.js@4.12.0:
@@ -6224,6 +6340,10 @@ packages:
 
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+    dev: false
+
+  /buffer-reverse@1.0.1:
+    resolution: {integrity: sha512-M87YIUBsZ6N924W57vDwT/aOu8hw7ZgdByz6ijksLjmHJELBASmYTTlNHRgjE+pTsT9oJXGaDSgqqwfdHotDUg==}
     dev: false
 
   /buffer-xor@1.0.3:
@@ -6787,6 +6907,10 @@ packages:
         optional: true
     dev: false
 
+  /crypto-js@4.2.0:
+    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+    dev: false
+
   /cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -7212,6 +7336,12 @@ packages:
       fast-safe-stringify: 2.1.1
     dev: false
 
+  /ethereum-bloom-filters@1.0.10:
+    resolution: {integrity: sha512-rxJ5OFN3RwjQxDcFP2Z5+Q9ho4eIdEmSc2ht0fCu8Se9nbXjZ7/031uXoUYJ87KHCOdVeiUuwSnoS7hmYAGVHA==}
+    dependencies:
+      js-sha3: 0.8.0
+    dev: false
+
   /ethereum-cryptography@0.1.3:
     resolution: {integrity: sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==}
     dependencies:
@@ -7321,6 +7451,14 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+    dev: false
+
+  /ethjs-unit@0.1.6:
+    resolution: {integrity: sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw==}
+    engines: {node: '>=6.5.0', npm: '>=3'}
+    dependencies:
+      bn.js: 4.11.6
+      number-to-bn: 1.7.0
     dev: false
 
   /ethjs-util@0.1.6:
@@ -9019,6 +9157,17 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
+  /merkletreejs@0.3.11:
+    resolution: {integrity: sha512-LJKTl4iVNTndhL+3Uz/tfkjD0klIWsHlUzgtuNnNrsf7bAlXR30m+xYB7lHr5Z/l6e/yAIsr26Dabx6Buo4VGQ==}
+    engines: {node: '>= 7.6.0'}
+    dependencies:
+      bignumber.js: 9.1.2
+      buffer-reverse: 1.0.1
+      crypto-js: 4.2.0
+      treeify: 1.1.0
+      web3-utils: 1.10.4
+    dev: false
+
   /metro-babel-transformer@0.80.6:
     resolution: {integrity: sha512-ssuoVC4OzqaOt3LpwfUbDfBlFGRu9v1Yf2JJnKPz0ROYHNjSBws4aUesqQQ/Ea8DbiH7TK4j4cJmm+XjdHmgqA==}
     engines: {node: '>=18'}
@@ -9437,6 +9586,10 @@ packages:
     resolution: {integrity: sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g==}
     dev: false
 
+  /napi-wasm@1.1.0:
+    resolution: {integrity: sha512-lHwIAJbmLSjF9VDRm9GoVOy9AGp3aIvkjv+Kvz9h16QR3uSVYH78PNQUnT2U4X53mhlnV2M7wrhibQ3GHicDmg==}
+    dev: false
+
   /negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
@@ -9576,6 +9729,14 @@ packages:
 
   /nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
+    dev: false
+
+  /number-to-bn@1.7.0:
+    resolution: {integrity: sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==}
+    engines: {node: '>=6.5.0', npm: '>=3'}
+    dependencies:
+      bn.js: 4.11.6
+      strip-hex-prefix: 1.0.0
     dev: false
 
   /ob1@0.80.6:
@@ -11279,6 +11440,11 @@ packages:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
     dev: false
 
+  /treeify@1.1.0:
+    resolution: {integrity: sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==}
+    engines: {node: '>=0.6'}
+    dev: false
+
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -11557,6 +11723,10 @@ packages:
       node-gyp-build: 4.8.0
     dev: false
 
+  /utf8@3.0.0:
+    resolution: {integrity: sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==}
+    dev: false
+
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -11766,6 +11936,20 @@ packages:
       defaults: 1.0.4
     dev: false
 
+  /web3-utils@1.10.4:
+    resolution: {integrity: sha512-tsu8FiKJLk2PzhDl9fXbGUWTkkVXYhtTA+SmEFkKft+9BgwLxfCRpU96sWv7ICC8zixBNd3JURVoiR3dUXgP8A==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      '@ethereumjs/util': 8.1.0
+      bn.js: 5.2.1
+      ethereum-bloom-filters: 1.0.10
+      ethereum-cryptography: 2.1.3
+      ethjs-unit: 0.1.6
+      number-to-bn: 1.7.0
+      randombytes: 2.1.0
+      utf8: 3.0.0
+    dev: false
+
   /webextension-polyfill-ts@0.25.0:
     resolution: {integrity: sha512-ikQhwwHYkpBu00pFaUzIKY26I6L87DeRI+Q6jBT1daZUNuu8dSrg5U9l/ZbqdaQ1M/TTSPKeAa3kolP5liuedw==}
     deprecated: This project has moved to @types/webextension-polyfill
@@ -11937,6 +12121,19 @@ packages:
 
   /ws@8.13.0:
     resolution: {integrity: sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: false
+
+  /ws@8.16.0:
+    resolution: {integrity: sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1

--- a/types/index.ts
+++ b/types/index.ts
@@ -59,7 +59,15 @@ export interface Report {
 
 	// properties regarding to hypercert marketplace
 	fundedSoFar: number;
+
+	order: Order | null;
 }
+
+/*************
+ *
+ * type definition from Hypercerts SDK
+ *
+ ************/
 
 /**
  * Represents 1 Hypercert
@@ -86,6 +94,30 @@ export interface Claim {
 	totalUnits?: any | null;
 	uri?: string | null;
 }
+
+// Represents an Order in the Hypercerts Marketplace
+export type Order = {
+	hypercertId: string;
+	additionalParameters: string;
+	amounts: number[];
+	chainId: number;
+	collection: string;
+	collectionType: number;
+	createdAt: string;
+	currency: string;
+	endTime: number;
+	globalNonce: string;
+	id: string;
+	itemIds: string[];
+	orderNonce: string;
+	price: string;
+	quoteType: number;
+	signature: string;
+	signer: string;
+	startTime: number;
+	strategyId: number;
+	subsetNonce: number;
+};
 
 /*************
  *


### PR DESCRIPTION
Marketplace orders that are linked to impact reports can now be accessed through the `fetchReports()` function. To make this possible, an `order` field has been added to the `Report` type. This allows for direct access to the `order` object associated with each report. For example:
```
const reports = fetchReports();
const order = reports[0].order;

// Code to process the order goes here...
```

To implement this feature, two new functions are added to the server: `fetchOrder(hypercertId: string)` for fetching individual orders, and `getOrders(reports: Report[])` for retrieving multiple orders.

Please note, the functionality to retrieve marketplace orders is available only when the ORDER_FETCHING environment variable is explicitly set to on. This is because the marketplace orders have not been created yet.