### PR TITLE
chore: use dummy orders

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,117 @@
+// NOTE
+// This is a workaround to mapping hypercerts minted by the safe wallet app and the dummy orders
+
+export const dummyFractions = {
+    "0xa16dfb32eb140a6f3f2ac68f41dad8c7e83c4941-72820426521080831181162165990398397251584": {
+      "id": "0xa16dfb32eb140a6f3f2ac68f41dad8c7e83c4941-86431721197918369719697150287669125709825",
+      "owner": "0xa92fddaee63d977fba1913ec2d5916df777ee6c3",
+      "tokenID": "86431721197918369719697150287669125709825",
+      "units": "10000",
+      "claim": {
+        "id": "0xa16dfb32eb140a6f3f2ac68f41dad8c7e83c4941-86431721197918369719697150287669125709824",
+        "creation": "1710541524",
+        "uri": "bafkreihgmdcqav5h6lkhyq3zvy7nxwcvv7ippeqqzf63ttlysdygiumali",
+        "totalUnits": "10000",
+        "__typename": "Claim"
+      },
+      "__typename": "ClaimToken"
+    },
+    "0xa16dfb32eb140a6f3f2ac68f41dad8c7e83c4941-73160708888001769644625540597830165463040": {
+      "id": "0xa16dfb32eb140a6f3f2ac68f41dad8c7e83c4941-86772003564839308183160524895100893921281",
+      "owner": "0xa92fddaee63d977fba1913ec2d5916df777ee6c3",
+      "tokenID": "86772003564839308183160524895100893921281",
+      "units": "10000",
+      "claim": {
+        "id": "0xa16dfb32eb140a6f3f2ac68f41dad8c7e83c4941-86772003564839308183160524895100893921280",
+        "creation": "1710541608",
+        "uri": "bafkreicrq2rfezmvpdyidzmwpbij7bf6nft5ogmabnxkp2izqo4kt3slvy",
+        "totalUnits": "10000",
+        "__typename": "Claim"
+      },
+      "__typename": "ClaimToken"
+    },
+    "0xa16dfb32eb140a6f3f2ac68f41dad8c7e83c4941-73500991254922708108088915205261933674496": {
+      "id": "0xa16dfb32eb140a6f3f2ac68f41dad8c7e83c4941-87112285931760246646623899502532662132737",
+      "owner": "0xa92fddaee63d977fba1913ec2d5916df777ee6c3",
+      "tokenID": "87112285931760246646623899502532662132737",
+      "units": "10000",
+      "claim": {
+        "id": "0xa16dfb32eb140a6f3f2ac68f41dad8c7e83c4941-87112285931760246646623899502532662132736",
+        "creation": "1710541800",
+        "uri": "bafkreibwwncm6eciui6lklmenupfwqcvcbshpbu3nolqf6rrohxotsq6cy",
+        "totalUnits": "10000",
+        "__typename": "Claim"
+      },
+      "__typename": "ClaimToken"
+    },
+    "0xa16dfb32eb140a6f3f2ac68f41dad8c7e83c4941-73841273621843646571552289812693701885952": {
+      "id": "0xa16dfb32eb140a6f3f2ac68f41dad8c7e83c4941-87452568298681185110087274109964430344193",
+      "owner": "0xa92fddaee63d977fba1913ec2d5916df777ee6c3",
+      "tokenID": "87452568298681185110087274109964430344193",
+      "units": "10000",
+      "claim": {
+        "id": "0xa16dfb32eb140a6f3f2ac68f41dad8c7e83c4941-87452568298681185110087274109964430344192",
+        "creation": "1710541884",
+        "uri": "bafkreiamyfmeftjgguzrl335zkz4hotm65xu4ebrlxnhucvpffsicl77fq",
+        "totalUnits": "10000",
+        "__typename": "Claim"
+      },
+      "__typename": "ClaimToken"
+    },
+    "0xa16dfb32eb140a6f3f2ac68f41dad8c7e83c4941-74181555988764585035015664420125470097408": {
+      "id": "0xa16dfb32eb140a6f3f2ac68f41dad8c7e83c4941-87792850665602123573550648717396198555649",
+      "owner": "0xa92fddaee63d977fba1913ec2d5916df777ee6c3",
+      "tokenID": "87792850665602123573550648717396198555649",
+      "units": "10000",
+      "claim": {
+        "id": "0xa16dfb32eb140a6f3f2ac68f41dad8c7e83c4941-87792850665602123573550648717396198555648",
+        "creation": "1710542004",
+        "uri": "bafkreihflmmbfofxzur5t7trcquymm2azgyhtnke57yr6higxp2ajkxppy",
+        "totalUnits": "10000",
+        "__typename": "Claim"
+      },
+      "__typename": "ClaimToken"
+    },
+    "0xa16dfb32eb140a6f3f2ac68f41dad8c7e83c4941-74521838355685523498479039027557238308864": {
+      "id": "0xa16dfb32eb140a6f3f2ac68f41dad8c7e83c4941-88133133032523062037014023324827966767105",
+      "owner": "0xa92fddaee63d977fba1913ec2d5916df777ee6c3",
+      "tokenID": "88133133032523062037014023324827966767105",
+      "units": "10000",
+      "claim": {
+        "id": "0xa16dfb32eb140a6f3f2ac68f41dad8c7e83c4941-88133133032523062037014023324827966767104",
+        "creation": "1710542088",
+        "uri": "bafkreid26uf2upmq5e7ccjpt3brdw3uqkzfitvts7i4zehgwrl3ippnlya",
+        "totalUnits": "10000",
+        "__typename": "Claim"
+      },
+      "__typename": "ClaimToken"
+    },
+    "0xa16dfb32eb140a6f3f2ac68f41dad8c7e83c4941-74862120722606461961942413634989006520320": {
+      "id": "0xa16dfb32eb140a6f3f2ac68f41dad8c7e83c4941-88473415399444000500477397932259734978561",
+      "owner": "0xa92fddaee63d977fba1913ec2d5916df777ee6c3",
+      "tokenID": "88473415399444000500477397932259734978561",
+      "units": "10000",
+      "claim": {
+        "id": "0xa16dfb32eb140a6f3f2ac68f41dad8c7e83c4941-88473415399444000500477397932259734978560",
+        "creation": "1710542220",
+        "uri": "bafkreibtfefzbdrpruxsyhaqg4flbkuahwfwchk4smaw4uzzl5hut7dlb4",
+        "totalUnits": "10000",
+        "__typename": "Claim"
+      },
+      "__typename": "ClaimToken"
+    },
+    "0xa16dfb32eb140a6f3f2ac68f41dad8c7e83c4941-75202403089527400425405788242420774731776": {
+      "id": "0xa16dfb32eb140a6f3f2ac68f41dad8c7e83c4941-88813697766364938963940772539691503190017",
+      "owner": "0xa92fddaee63d977fba1913ec2d5916df777ee6c3",
+      "tokenID": "88813697766364938963940772539691503190017",
+      "units": "10000",
+      "claim": {
+        "id": "0xa16dfb32eb140a6f3f2ac68f41dad8c7e83c4941-88813697766364938963940772539691503190016",
+        "creation": "1710542268",
+        "uri": "bafkreihzwjzdgckgfrfohmaixqicymijysrluykzqk2qtwgndqjyr4iyye",
+        "totalUnits": "10000",
+        "__typename": "Claim"
+      },
+      "__typename": "ClaimToken"
+    }
+  }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@ethersproject/providers": "^5.7.2",
     "@fontsource-variable/plus-jakarta-sans": "^5.0.20",
     "@hookform/resolvers": "^3.3.4",
-    "@hypercerts-org/marketplace-sdk": "^0.0.23",
+    "@hypercerts-org/marketplace-sdk": "0.0.24",
     "@hypercerts-org/sdk": "^1.4.3",
     "@radix-ui/react-aspect-ratio": "^1.0.3",
     "@radix-ui/react-avatar": "^1.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ dependencies:
     specifier: ^3.3.4
     version: 3.3.4(react-hook-form@7.51.1)
   '@hypercerts-org/marketplace-sdk':
-    specifier: ^0.0.23
-    version: 0.0.23(ethers@6.11.1)(react@18.2.0)(typescript@5.4.2)(zod@3.22.4)
+    specifier: 0.0.24
+    version: 0.0.24(ethers@6.11.1)(react@18.2.0)(typescript@5.4.2)(zod@3.22.4)
   '@hypercerts-org/sdk':
     specifier: ^1.4.3
     version: 1.4.3(react@18.2.0)(typescript@5.4.2)(zod@3.22.4)
@@ -2368,8 +2368,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@hypercerts-org/marketplace-sdk@0.0.23(ethers@6.11.1)(react@18.2.0)(typescript@5.4.2)(zod@3.22.4):
-    resolution: {integrity: sha512-9I7F/waSMxUtvzjzaaEM/2YOpR2y54jdCjTLQutFr5sr8TbqRqIvFpJ4emLB4ri6DadLgHDFGrQCHqSL31jKxw==}
+  /@hypercerts-org/marketplace-sdk@0.0.24(ethers@6.11.1)(react@18.2.0)(typescript@5.4.2)(zod@3.22.4):
+    resolution: {integrity: sha512-5lRVcClMAKlpkdM/XgCs8QFPD5DaHz3pfu1rgw5hObQabZjEILWPV7BSoQNIxWuER8oa94DlSYyVNlCKuWgczw==}
     engines: {node: '>= 16.15.1 <= 20.x'}
     peerDependencies:
       ethers: ^6.6.2

--- a/types/index.ts
+++ b/types/index.ts
@@ -5,6 +5,7 @@ import type { Address, Hash } from "viem";
  *
  * @interface Report
  * @property {string} hypercertId - Claim id of hypercert.
+ * @property {string} tokenID - Token id of hypercert.
  * @property {string} title - Title of the report.
  * @property {string} summary - Brief summary of the report.
  * @property {string} image - the image representing the report.
@@ -30,18 +31,19 @@ import type { Address, Hash } from "viem";
  * @property {number} fundedSoFar - Amount funded so far.
  */
 export interface Report {
-  // properties for hypercert minting
-  hypercertId: string;
-  title: string;
-  summary: string;
-  image: string;
-  originalReportUrl: string;
-  state: string;
-  category: string;
-  workTimeframe: string;
-  impactScope: string;
-  impactTimeframe: string;
-  contributors: string[];
+	// properties for hypercert minting
+	hypercertId: string;
+	tokenID: string;
+	title: string;
+	summary: string;
+	image: string;
+	originalReportUrl: string;
+	state: string;
+	category: string;
+	workTimeframe: string;
+	impactScope: string;
+	impactTimeframe: string;
+	contributors: string[];
 
   // properties stored in CMS
   cmsId: string;


### PR DESCRIPTION
This PR introduecs feature flag:

if 
* `NEXT_PUBLIC_ORDER_WORKAROUND` is set to `on` then the app will running as workaround mode
* `ORDER_FETCHING` is set to `on` then the app will fetch orders associated with hypercert claim id
* `NEXT_PUBLIC_ORDER_WORKAROUND` or `ORDER_FETCHING` has no value  then the app will attach single dummy order tot every impact report