### PR TITLE
feat: update CMS immediately after tx submission

### DIFF
--- a/hooks/use-buy-fraction.ts
+++ b/hooks/use-buy-fraction.ts
@@ -22,7 +22,9 @@ const useHandleBuyFraction = (
     // biome-ignore lint/suspicious/noExplicitAny: <explanation>
     order: any,
     amount: number,
-    address?: Address
+    address: Address,
+    hypercertId: string | undefined,
+    comment: string | undefined,
   ) => {
     if (!publicClient) {
       throw new Error("No public client found");
@@ -35,7 +37,7 @@ const useHandleBuyFraction = (
       order,
       address,
       amount,
-      order.price
+      order.price,
     );
 
     try {
@@ -60,7 +62,22 @@ const useHandleBuyFraction = (
         takerOrder,
         order.signature
       );
+
       const tx = await call();
+
+      fetch("/api/contributions", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          txId: tx.hash as `0x${string}`,
+          hypercertId: hypercertId,
+          amount: amount,
+          comment: comment,
+        }),
+      });
+
       setTransactionHash(tx.hash as Address);
       const txnReceipt = await waitForTransactionReceipt(publicClient, {
         hash: tx.hash as `0x${string}`,

--- a/hooks/use-support-form.ts
+++ b/hooks/use-support-form.ts
@@ -51,21 +51,7 @@ const useSupportForm = (
       throw new Error("No address found");
     }
 
-    const txnReceipt = await handleBuyFraction(order, unitsToBuy, address);
-    if (txnReceipt) {
-      await fetch("/api/contributions", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          txId: txnReceipt.transactionHash as `0x${string}`,
-          hypercertId: hypercertId ?? "",
-          amount: values.fractionPayment,
-          comment: values.comment,
-        }),
-      });
-    }
+    await handleBuyFraction(order, unitsToBuy, address, hypercertId, values.comment);
   };
 
   return { form, isProcessing, onSubmit };


### PR DESCRIPTION
Implemented an immediate CMS update request following transaction submission, ensuring no update is missed even if the browser is closed post-transaction