### PR TITLE
Implement rate limiting for `getHypercertMetadata` requests

### DIFF
--- a/lib/impact-reports.ts
+++ b/lib/impact-reports.ts
@@ -12,6 +12,7 @@ import { Mutex } from "async-mutex";
 import type { Claim, Report } from "@/types";
 import { getCMSReports, getFundedAmountByHCId } from "./directus";
 import { getOrders } from "./marketplace";
+import { delay } from './utils';
 
 let reports: Report[] | null = null;
 const reportsMutex = new Mutex();
@@ -47,6 +48,10 @@ export const fetchReports = async (): Promise<Report[]> => {
       reports = await Promise.all(
         claims.map(async (claim, index) => {
           // step 1: get metadata from IPFS
+
+          // a delay based on the index to spread out the requests
+          await delay(index * 100);
+
           const metadata = await getHypercertMetadata(
             claim.uri as string,
             getHypercertClient().storage

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -40,3 +40,5 @@ export const truncateEthereumAddress = (
 export const isNotNull = <T>(value: T | null): value is T => {
   return value !== null;
 };
+
+export const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));


### PR DESCRIPTION
To avoid hitting the rate limits of the remote server, a delay has been introduced between each call to getHypercertMetadata in the fetchReports function. This is achieved by adding a dynamic delay based on the index of the current claim in the iteration, ensuring that requests are spread out over time. This approach helps in managing the request rate effectively, preventing failures due to excessive concurrent requests.