### PR TITLE
Fix/disable display name

### DIFF
--- a/components/settings/user-info.tsx
+++ b/components/settings/user-info.tsx
@@ -45,7 +45,8 @@ const UserInfo = () => {
 						className="mb-0"
 						type="displayName"
 						placeholder={ensName ? ensName : "Voice Deck"}
-						disabled={ensName ? true : false}
+						// disabled={ensName ? true : false}
+						disabled={true}
 					/>
 					<small className="text-xs">
 						We'll use your ENS name if you have one or you can set your own in


### PR DESCRIPTION
## Linear Ticket

NA

## Overview

Disabled the input for display name when a user does not have an ENS.

## Installations Needed

NA

## Screencaps
<img width="1509" alt="Screenshot 2024-03-25 at 10 26 43 AM" src="https://github.com/VoiceDeck/app/assets/22626267/93db246d-b50a-4879-bba8-b0c1b614cbaf">

Considering adding a screenshot or screencapture of the changes.

## Checks

Before making your PR, please check the following:

- [x] Critical lint errors are resolved
- [x] App runs locally
- [x] App builds locally (run the `npm build` and resolve any errors before the PR when possible)
