### PR TITLE
 feat: add `api/reports/update` endpoint 

### DIFF
--- a/app/api/reports/update/route.ts
+++ b/app/api/reports/update/route.ts
@@ -1,0 +1,17 @@
+import { fetchNewReports } from "@/lib/impact-reports";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+	try {
+		await fetchNewReports();
+		return NextResponse.json({ status: 200 });
+	} catch (error) {
+		let errorMessage = "An unknown error occurred";
+		if (typeof error === "object" && error !== null) {
+			errorMessage = (error as { message?: string }).message ?? errorMessage;
+		} else if (typeof error === "string") {
+			errorMessage = error;
+		}
+		return NextResponse.json({ error: errorMessage }, { status: 500 });
+	}
+}


### PR DESCRIPTION
This PR add `api/reports/update` endpoint to allow admin to call this endpoint when new reports are minted as hypercert and so to update server cache