### PR TITLE
Update CMS Instantly on Contribution and Add Validation Delay

### DIFF
--- a/app/api/contributions/route.ts
+++ b/app/api/contributions/route.ts
@@ -3,14 +3,15 @@ import { type NextRequest, NextResponse } from "next/server";
 
 export async function POST(req: NextRequest) {
 	try {
-		const { txId, hypercertId, amount, comment } = await req.json();
-		if (!txId || !hypercertId || !amount) {
+		const { sender, txId, hypercertId, amount, comment } = await req.json();
+		if (!sender || !txId || !hypercertId || !amount) {
 			return NextResponse.json(
 				{ error: "Missing required fields" },
 				{ status: 400 },
 			);
 		}
 		const result = await processNewContribution(
+			sender,
 			txId,
 			hypercertId,
 			amount,

--- a/app/api/contributions/validate/route.ts
+++ b/app/api/contributions/validate/route.ts
@@ -1,0 +1,42 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+import { getViemClient, removeContribution } from "@/lib/directus";
+
+export async function POST(req: NextRequest) {
+	try {
+		const { txId } = await req.json();
+		if (!txId) {
+			return NextResponse.json(
+				{ error: "Missing required fields" },
+				{ status: 400 },
+			);
+		}
+
+		const viemClient = getViemClient();
+
+		// wait for the transaction to be included in a block
+		console.log(
+			`[Viem] waiting for tx ${txId} to be included in a block . . .`,
+		);
+		const txReceipt = await viemClient.waitForTransactionReceipt({
+			hash: txId,
+		});
+		console.log(`[Viem] tx ${txId} included in block ${txReceipt.blockNumber}`);
+
+		if (txReceipt.status === "reverted") {
+			console.log(`[Viem] tx ${txId} reverted, remove from CMS . . .`);
+
+			await removeContribution(txId);
+			return NextResponse.json({ txStatus: "deleted" }, { status: 200 });
+		}
+		return NextResponse.json({ txStatus: "ok" }, { status: 200 });
+	} catch (error) {
+		let errorMessage = "An unknown error occurred";
+		if (typeof error === "object" && error !== null) {
+			errorMessage = (error as { message?: string }).message ?? errorMessage;
+		} else if (typeof error === "string") {
+			errorMessage = error;
+		}
+		return NextResponse.json({ error: errorMessage }, { status: 500 });
+	}
+}

--- a/hooks/use-buy-fraction.ts
+++ b/hooks/use-buy-fraction.ts
@@ -39,11 +39,7 @@ const useHandleBuyFraction = (
       throw new Error("No order found");
     }
 
-    // if I enter 1 USD to buy in the UI, the amount will be 1000000000000000n
-    // amount: 1000000000000000n (10^15)
-    // pricePerUnit: 1
     console.log({ order, amount, address, hypercertId, comment });
-    // print order.price
     console.log(order.price);
     const takerOrder = hypercertExhangeClient.createFractionalSaleTakerBid(
       order,
@@ -72,6 +68,7 @@ const useHandleBuyFraction = (
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
+          sender: address,
           txId: tx.hash as `0x${string}`,
           hypercertId: hypercertId,
           amount: amountInDollars,


### PR DESCRIPTION
This PR introduces two major changes to improve how contributions are reflected in the CMS:

* Instant CMS Update: Upon a contribution event, the CMS is now immediately updated to reflect the new contribution. 
* Delayed Validation: After updating the CMS, the CMS now waits for 30 seconds before calling the `api/contributions/validate` route. This validation step checks if the contribution tx has been successfully processed and included in a block. If the tx is reverted for any reason, the corresponding contribution entry is removed from the CMS. 

Background Issue: Previously, the CMS entry for a contribution was created only after the backend confirmed that the transaction was successfully included in a block. However, this process faced a critical issue with Netlify's 10-second execution limit. If the transaction receipt could not be obtained within 10 seconds, the CMS failed to update with the new contribution data, leading to missing entries