### PR TITLE
fix: fill `date_created` field from server-side

### DIFF
--- a/lib/directus.ts
+++ b/lib/directus.ts
@@ -74,6 +74,7 @@ export async function processNewContribution(
       hypercert_id: hypercertId,
       amount: amount,
       txid: txId,
+      date_created: new Date().toISOString(),
       comment: comment,
     } as Contribution;
     // create a contribution record in Directus


### PR DESCRIPTION
This PR addresses the issue where an `invalid date` is displayed right after a user contributes to a specific report