### PR TITLE
fix: fix `bun install` failure

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,4 @@
+[install]
+
+# Prevent the package manager from installing the grpc package, which we do not use. See more details in https://github.com/VoiceDeck/app/issues/95#issuecomment-2104509962
+peer = false


### PR DESCRIPTION
This PR fixes `bun install` failure caused by unused dependency. See this for detailed cause analysis: https://github.com/VoiceDeck/app/issues/95#issuecomment-2104509962

Fixes #95 